### PR TITLE
fix: add compatibility for pre-v0.12 RVV spec toolchains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,26 @@ deps := $(OBJS:%.o=%.o.d)
 	$(CXX) -o $@ $(CXXFLAGS) $(DEFINED_FLAGS) -c -MMD -MF $@.d $<
 
 EXEC = tests/main
+COMPAT_TEST = tests/compat_test
 
 $(EXEC): $(OBJS)
 	$(CXX) $(LDFLAGS) -o $@ $^
+
+$(COMPAT_TEST): tests/compat_test.cpp sse2rvv.h
+	$(CXX) -o $@ $(CXXFLAGS) $(LDFLAGS) tests/compat_test.cpp
 
 test: tests/main
 ifeq ($(processor),$(filter $(processor),rv32 rv64))
 	$(CC) $(ARCH_CFLAGS) -c sse2rvv.h
 endif
 	$(SIMULATOR) $(SIMULATOR_FLAGS) $(PROXY_KERNEL) $^
+
+compat-test: $(COMPAT_TEST)
+ifeq ($(processor),$(filter $(processor),rv32 rv64))
+	$(SIMULATOR) $(SIMULATOR_FLAGS) $(PROXY_KERNEL) $^
+else
+	$^
+endif
 
 build-test: tests/main
 ifeq ($(processor),$(filter $(processor),rv32 rv64))
@@ -86,10 +97,10 @@ format:
 	@if ! hash clang-format; then echo "clang-format is required to indent"; fi
 	clang-format -i sse2rvv.h tests/*.cpp tests/*.h
 
-.PHONY: clean check format
+.PHONY: clean check format compat-test
 
 clean:
-	$(RM) $(OBJS) $(EXEC) $(deps) sse2rvv.h.gch
+	$(RM) $(OBJS) $(EXEC) $(COMPAT_TEST) $(deps) sse2rvv.h.gch
 
 clean-all: clean
 	$(RM) *.log

--- a/sse2rvv.h
+++ b/sse2rvv.h
@@ -248,17 +248,69 @@ typedef union ALIGN_STRUCT(16) SIMDVec {
 #endif
 #endif
 
-// XRM
-// #define __RISCV_VXRM_RNU 0  // round-to-nearest-up (add +0.5 LSB)
-// #define __RISCV_VXRM_RNE 1  // round-to-nearest-even
-// #define __RISCV_VXRM_RDN 2  // round-down (truncate)
-// #define __RISCV_VXRM_ROD 3  // round-to-odd (OR bits into LSB, aka "jam")
-// FRM
-// #define __RISCV_FRM_RNE 0  // round to nearest, ties to even
-// #define __RISCV_FRM_RTZ 1  // round towards zero
-// #define __RISCV_FRM_RDN 2  // round down (towards -infinity)
-// #define __RISCV_FRM_RUP 3  // round up (towards +infinity)
-// #define __RISCV_FRM_RMM 4  // round to nearest, ties to max magnitude
+// XRM rounding mode constants (defined in RVV intrinsics v0.12+)
+#ifndef __RISCV_VXRM_RNU
+#define __RISCV_VXRM_RNU 0  // round-to-nearest-up (add +0.5 LSB)
+#define __RISCV_VXRM_RNE 1  // round-to-nearest-even
+#define __RISCV_VXRM_RDN 2  // round-down (truncate)
+#define __RISCV_VXRM_ROD 3  // round-to-odd (OR bits into LSB, aka "jam")
+// GCC >= 14 uses pragma-based intrinsics that require the vxrm argument but
+// don't define __RISCV_VXRM_RNU as a preprocessor macro.
+#if !(defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 14)
+#define SSE2RVV_MISSING_VXRM
+#endif
+#endif
+// FRM rounding mode constants (defined in RVV intrinsics v0.12+)
+#ifndef __RISCV_FRM_RNE
+#define __RISCV_FRM_RNE 0  // round to nearest, ties to even
+#define __RISCV_FRM_RTZ 1  // round towards zero
+#define __RISCV_FRM_RDN 2  // round down (towards -infinity)
+#define __RISCV_FRM_RUP 3  // round up (towards +infinity)
+#define __RISCV_FRM_RMM 4  // round to nearest, ties to max magnitude
+#define SSE2RVV_MISSING_FRM
+#endif
+
+// Compatibility wrappers for fixed-point/fp intrinsics whose signatures changed
+// in RVV intrinsics v0.12 (added explicit rounding-mode parameter).
+#ifdef SSE2RVV_MISSING_VXRM
+#define sse2rvv_vaaddu_vv_u16m1(a, b, vxrm, vl) \
+  __riscv_vaaddu_vv_u16m1((a), (b), (vl))
+#define sse2rvv_vaaddu_vv_u8m1(a, b, vxrm, vl) \
+  __riscv_vaaddu_vv_u8m1((a), (b), (vl))
+#define sse2rvv_vnclip_wx_i16m1(a, b, vxrm, vl) \
+  __riscv_vnclip_wx_i16m1((a), (b), (vl))
+#define sse2rvv_vnclip_wx_i16m2(a, b, vxrm, vl) \
+  __riscv_vnclip_wx_i16m2((a), (b), (vl))
+#define sse2rvv_vnclip_wx_i8mf2(a, b, vxrm, vl) \
+  __riscv_vnclip_wx_i8mf2((a), (b), (vl))
+#define sse2rvv_vnclip_wx_i16mf2(a, b, vxrm, vl) \
+  __riscv_vnclip_wx_i16mf2((a), (b), (vl))
+#else
+#define sse2rvv_vaaddu_vv_u16m1 __riscv_vaaddu_vv_u16m1
+#define sse2rvv_vaaddu_vv_u8m1 __riscv_vaaddu_vv_u8m1
+#define sse2rvv_vnclip_wx_i16m1 __riscv_vnclip_wx_i16m1
+#define sse2rvv_vnclip_wx_i16m2 __riscv_vnclip_wx_i16m2
+#define sse2rvv_vnclip_wx_i8mf2 __riscv_vnclip_wx_i8mf2
+#define sse2rvv_vnclip_wx_i16mf2 __riscv_vnclip_wx_i16mf2
+#endif
+#ifdef SSE2RVV_MISSING_FRM
+#define sse2rvv_vfcvt_x_f_v_i32m1_rm(a, frm, vl) \
+  __riscv_vfcvt_x_f_v_i32m1((a), (vl))
+#else
+#define sse2rvv_vfcvt_x_f_v_i32m1_rm __riscv_vfcvt_x_f_v_i32m1_rm
+#endif
+// vsm argument order changed in GCC 14: old=(mask, ptr, vl), new=(ptr, mask, vl)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 14
+#define sse2rvv_vsm_v_b8(mask, ptr, vl) __riscv_vsm_v_b8((ptr), (mask), (vl))
+#define sse2rvv_vsm_v_b32(mask, ptr, vl) \
+  __riscv_vsm_v_b32((ptr), (mask), (vl))
+#define sse2rvv_vsm_v_b64(mask, ptr, vl) \
+  __riscv_vsm_v_b64((ptr), (mask), (vl))
+#else
+#define sse2rvv_vsm_v_b8 __riscv_vsm_v_b8
+#define sse2rvv_vsm_v_b32 __riscv_vsm_v_b32
+#define sse2rvv_vsm_v_b64 __riscv_vsm_v_b64
+#endif
 
 // The bit field mapping to the FCSR (floating-point control and status
 // register)
@@ -433,8 +485,8 @@ FORCE_INLINE __m128 _mm_addsub_ps(__m128 a, __m128 b) {
   vfloat32m1_t _b = vreinterpretq_m128_f32(b);
   vfloat32m1_t add = __riscv_vfadd_vv_f32m1(_a, _b, 4);
   vfloat32m1_t sub = __riscv_vfsub_vv_f32m1(_a, _b, 4);
-  vbool32_t mask =
-      __riscv_vreinterpret_v_i32m1_b32(__riscv_vmv_s_x_i32m1(0xa, 4));
+  uint8_t _mask_u8 = 0xa;
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_u8, 4);
   return vreinterpretq_f32_m128(__riscv_vmerge_vvm_f32m1(sub, add, mask, 4));
 }
 
@@ -496,14 +548,14 @@ FORCE_INLINE __m128i _mm_avg_epu16(__m128i a, __m128i b) {
   vuint16m1_t _a = vreinterpretq_m128i_u16(a);
   vuint16m1_t _b = vreinterpretq_m128i_u16(b);
   return vreinterpretq_u16_m128i(
-      __riscv_vaaddu_vv_u16m1(_a, _b, __RISCV_VXRM_RNU, 8));
+      sse2rvv_vaaddu_vv_u16m1(_a, _b, __RISCV_VXRM_RNU, 8));
 }
 
 FORCE_INLINE __m128i _mm_avg_epu8(__m128i a, __m128i b) {
   vuint8m1_t _a = vreinterpretq_m128i_u8(a);
   vuint8m1_t _b = vreinterpretq_m128i_u8(b);
   return vreinterpretq_u8_m128i(
-      __riscv_vaaddu_vv_u8m1(_a, _b, __RISCV_VXRM_RNU, 16));
+      sse2rvv_vaaddu_vv_u8m1(_a, _b, __RISCV_VXRM_RNU, 16));
 }
 
 FORCE_INLINE __m64 _mm_avg_pu16(__m64 a, __m64 b) {
@@ -513,37 +565,37 @@ FORCE_INLINE __m64 _mm_avg_pu16(__m64 a, __m64 b) {
   vint16m1_t __b = __riscv_vreinterpret_v_i32m1_i16m1(b);
   vuint16m1_t _b = __riscv_vreinterpret_v_i16m1_u16m1(__b);
   return vreinterpretq_u16_m64(
-      __riscv_vaaddu_vv_u16m1(_a, _b, __RISCV_VXRM_RNU, 4));
+      sse2rvv_vaaddu_vv_u16m1(_a, _b, __RISCV_VXRM_RNU, 4));
 }
 
 FORCE_INLINE __m64 _mm_avg_pu8(__m64 a, __m64 b) {
   vuint8m1_t _a = vreinterpretq_m64_u8(a);
   vuint8m1_t _b = vreinterpretq_m64_u8(b);
   return vreinterpretq_u8_m64(
-      __riscv_vaaddu_vv_u8m1(_a, _b, __RISCV_VXRM_RNU, 8));
+      sse2rvv_vaaddu_vv_u8m1(_a, _b, __RISCV_VXRM_RNU, 8));
 }
 
 FORCE_INLINE __m128i _mm_blend_epi16(__m128i a, __m128i b, const int imm8) {
   vint16m1_t _a = vreinterpretq_m128i_i16(a);
   vint16m1_t _b = vreinterpretq_m128i_i16(b);
-  vbool16_t _imm8 =
-      __riscv_vreinterpret_v_i8m1_b16(__riscv_vmv_s_x_i8m1(imm8, 8));
+  uint8_t _imm8_b = (uint8_t)imm8;
+  vbool16_t _imm8 = __riscv_vlm_v_b16(&_imm8_b, 8);
   return vreinterpretq_i16_m128i(__riscv_vmerge_vvm_i16m1(_a, _b, _imm8, 8));
 }
 
 FORCE_INLINE __m128d _mm_blend_pd(__m128d a, __m128d b, const int imm8) {
   vfloat64m1_t _a = vreinterpretq_m128d_f64(a);
   vfloat64m1_t _b = vreinterpretq_m128d_f64(b);
-  vbool64_t _imm8 =
-      __riscv_vreinterpret_v_i8m1_b64(__riscv_vmv_s_x_i8m1(imm8, 2));
+  uint8_t _imm8_b = (uint8_t)imm8;
+  vbool64_t _imm8 = __riscv_vlm_v_b64(&_imm8_b, 2);
   return vreinterpretq_f64_m128d(__riscv_vmerge_vvm_f64m1(_a, _b, _imm8, 2));
 }
 
 FORCE_INLINE __m128 _mm_blend_ps(__m128 a, __m128 b, const int imm8) {
   vfloat32m1_t _a = vreinterpretq_m128_f32(a);
   vfloat32m1_t _b = vreinterpretq_m128_f32(b);
-  vbool32_t _imm8 =
-      __riscv_vreinterpret_v_i8m1_b32(__riscv_vmv_s_x_i8m1(imm8, 4));
+  uint8_t _imm8_b = (uint8_t)imm8;
+  vbool32_t _imm8 = __riscv_vlm_v_b32(&_imm8_b, 4);
   return vreinterpretq_f32_m128(__riscv_vmerge_vvm_f32m1(_a, _b, _imm8, 4));
 }
 
@@ -1381,7 +1433,7 @@ FORCE_INLINE __m128 _mm_cvt_si2ss(__m128 a, int b) {
 
 FORCE_INLINE int _mm_cvt_ss2si(__m128 a) {
   vfloat32m1_t _a = vreinterpretq_m128_f32(a);
-  vint32m1_t a_i32 = __riscv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RNE, 1);
+  vint32m1_t a_i32 = sse2rvv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RNE, 1);
   return (int)(__riscv_vmv_x_s_i32m1_i32(a_i32));
 }
 
@@ -1715,7 +1767,8 @@ FORCE_INLINE __m128d _mm_hadd_pd(__m128d a, __m128d b) {
   vfloat64m2_t ab = __riscv_vslideup_vx_f64m2_tu(_a, _b, 2, 4);
   vfloat64m2_t ab_s = __riscv_vslidedown_vx_f64m2(ab, 1, 4);
   vfloat64m2_t ab_add = __riscv_vfadd_vv_f64m2(ab, ab_s, 4);
-  vbool32_t mask = __riscv_vreinterpret_v_u8m1_b32(__riscv_vmv_s_x_u8m1(85, 2));
+  uint8_t _mask_val = 85;
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_val, 4);
   return vreinterpretq_f64_m128d(__riscv_vlmul_trunc_v_f64m2_f64m1(
       __riscv_vcompress_vm_f64m2(ab_add, mask, 4)));
 }
@@ -1799,7 +1852,8 @@ FORCE_INLINE __m128d _mm_hsub_pd(__m128d a, __m128d b) {
   vfloat64m2_t ab = __riscv_vslideup_vx_f64m2_tu(_a, _b, 2, 4);
   vfloat64m2_t ab_s = __riscv_vslidedown_vx_f64m2(ab, 1, 4);
   vfloat64m2_t ab_sub = __riscv_vfsub_vv_f64m2(ab, ab_s, 4);
-  vbool32_t mask = __riscv_vreinterpret_v_u8m1_b32(__riscv_vmv_s_x_u8m1(85, 2));
+  uint8_t _mask_val = 85;
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_val, 4);
   return vreinterpretq_f64_m128d(__riscv_vlmul_trunc_v_f64m2_f64m1(
       __riscv_vcompress_vm_f64m2(ab_sub, mask, 4)));
 }
@@ -1859,36 +1913,36 @@ FORCE_INLINE __m64 _mm_hsubs_pi16(__m64 a, __m64 b) {
 
 FORCE_INLINE __m128i _mm_insert_epi16(__m128i a, int i, int imm8) {
   vint16m1_t _a = vreinterpretq_m128i_i16(a);
-  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(
-      __riscv_vmv_s_x_u8m1(((uint8_t)(1 << (imm8 & 0x7))), 8));
+  uint8_t _mask_val = (uint8_t)(1 << (imm8 & 0x7));
+  vbool16_t mask = __riscv_vlm_v_b16(&_mask_val, 8);
   return vreinterpretq_i16_m128i(__riscv_vmerge_vxm_i16m1(_a, i, mask, 8));
 }
 
 FORCE_INLINE __m128i _mm_insert_epi32(__m128i a, int i, const int imm8) {
   vint32m1_t _a = vreinterpretq_m128i_i32(a);
-  vbool32_t mask = __riscv_vreinterpret_v_u8m1_b32(
-      __riscv_vmv_s_x_u8m1(((uint8_t)(1 << (imm8 & 0x3))), 4));
+  uint8_t _mask_val = (uint8_t)(1 << (imm8 & 0x3));
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_val, 4);
   return vreinterpretq_i32_m128i(__riscv_vmerge_vxm_i32m1(_a, i, mask, 4));
 }
 
 FORCE_INLINE __m128i _mm_insert_epi64(__m128i a, __int64 i, const int imm8) {
   vint64m1_t _a = vreinterpretq_m128i_i64(a);
-  vbool64_t mask = __riscv_vreinterpret_v_u8m1_b64(
-      __riscv_vmv_s_x_u8m1(((uint8_t)(1 << (imm8 & 0x1))), 2));
+  uint8_t _mask_val = (uint8_t)(1 << (imm8 & 0x1));
+  vbool64_t mask = __riscv_vlm_v_b64(&_mask_val, 2);
   return vreinterpretq_i64_m128i(__riscv_vmerge_vxm_i64m1(_a, i, mask, 2));
 }
 
 FORCE_INLINE __m128i _mm_insert_epi8(__m128i a, int i, const int imm8) {
   vint8m1_t _a = vreinterpretq_m128i_i8(a);
-  vbool8_t mask = __riscv_vreinterpret_v_u16m1_b8(
-      __riscv_vmv_s_x_u16m1(((uint16_t)(1 << (imm8 & 0xf))), 16));
+  uint16_t _mask_u16 = (uint16_t)(1 << (imm8 & 0xf));
+  vbool8_t mask = __riscv_vlm_v_b8((uint8_t *)&_mask_u16, 16);
   return vreinterpretq_i8_m128i(__riscv_vmerge_vxm_i8m1(_a, i, mask, 16));
 }
 
 FORCE_INLINE __m64 _mm_insert_pi16(__m64 a, int i, int imm8) {
   vint16m1_t _a = vreinterpretq_m64_i16(a);
-  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(
-      __riscv_vmv_s_x_u8m1(((uint8_t)(1 << imm8)), 8));
+  uint8_t _mask_val = (uint8_t)(1 << imm8);
+  vbool16_t mask = __riscv_vlm_v_b16(&_mask_val, 8);
   return vreinterpretq_i16_m64(__riscv_vmerge_vxm_i16m1(_a, i, mask, 8));
 }
 
@@ -1897,11 +1951,11 @@ FORCE_INLINE __m128 _mm_insert_ps(__m128 a, __m128 b, const int imm8) {
   vint32m1_t _b = vreinterpretq_m128_i32(b);
   vint32m1_t tmp =
       __riscv_vrgather_vx_i32m1(_b, (((uint8_t)imm8) >> 6) & 0x3, 4);
-  vbool32_t mask1 = __riscv_vreinterpret_v_u32m1_b32(
-      __riscv_vmv_s_x_u32m1((1 << ((imm8 >> 4) & 0x3)), 4));
+  uint8_t _mask1_val = (uint8_t)(1 << ((imm8 >> 4) & 0x3));
+  vbool32_t mask1 = __riscv_vlm_v_b32(&_mask1_val, 4);
   vint32m1_t tmp2 = __riscv_vmerge_vvm_i32m1(_a, tmp, mask1, 4);
-  vbool32_t mask2 =
-      __riscv_vreinterpret_v_u32m1_b32(__riscv_vmv_s_x_u32m1(imm8 & 0xf, 4));
+  uint8_t _mask2_val = (uint8_t)(imm8 & 0xf);
+  vbool32_t mask2 = __riscv_vlm_v_b32(&_mask2_val, 4);
   return vreinterpretq_i32_m128(__riscv_vmerge_vxm_i32m1(tmp2, 0, mask2, 4));
 }
 
@@ -2020,14 +2074,16 @@ FORCE_INLINE __m128i _mm_loadu_si128(__m128i const *mem_addr) {
 FORCE_INLINE __m128i _mm_loadu_si16(void const *mem_addr) {
   vint16m1_t ld = __riscv_vle16_v_i16m1((int16_t const *)mem_addr, 1);
   vint16m1_t zeros = __riscv_vmv_v_x_i16m1(0, 8);
-  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(__riscv_vmv_v_x_u8m1(1, 8));
+  uint8_t _mask_val = 1;
+  vbool16_t mask = __riscv_vlm_v_b16(&_mask_val, 8);
   return vreinterpretq_i16_m128i(__riscv_vmerge_vvm_i16m1(zeros, ld, mask, 8));
 }
 
 FORCE_INLINE __m128i _mm_loadu_si32(void const *mem_addr) {
   vint32m1_t ld = __riscv_vle32_v_i32m1((int32_t const *)mem_addr, 1);
   vint32m1_t zeros = __riscv_vmv_v_x_i32m1(0, 4);
-  vbool32_t mask = __riscv_vreinterpret_v_u8m1_b32(__riscv_vmv_v_x_u8m1(1, 4));
+  uint8_t _mask_val = 1;
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_val, 4);
   return vreinterpretq_i32_m128i(__riscv_vmerge_vvm_i32m1(zeros, ld, mask, 4));
 }
 
@@ -2054,7 +2110,7 @@ FORCE_INLINE __m128i _mm_maddubs_epi16(__m128i a, __m128i b) {
   vint16m2_t mul = __riscv_vmul_vv_i16m2(_a, _b, 16);
   vint16m2_t mul_s = __riscv_vslidedown_vx_i16m2(mul, 1, 16);
   vint32m4_t mul_add = __riscv_vwadd_vv_i32m4(mul, mul_s, 16);
-  vint16m2_t sat = __riscv_vnclip_wx_i16m2(mul_add, 0, __RISCV_VXRM_RDN, 16);
+  vint16m2_t sat = sse2rvv_vnclip_wx_i16m2(mul_add, 0, __RISCV_VXRM_RDN, 16);
   return vreinterpretq_i16_m128i(
       __riscv_vnsra_wx_i16m1(__riscv_vreinterpret_v_i16m2_i32m2(sat), 0, 16));
 }
@@ -2066,7 +2122,7 @@ FORCE_INLINE __m64 _mm_maddubs_pi16(__m64 a, __m64 b) {
   vint16m2_t mul = __riscv_vmul_vv_i16m2(_a, _b, 8);
   vint16m2_t mul_s = __riscv_vslidedown_vx_i16m2(mul, 1, 8);
   vint32m4_t mul_add = __riscv_vwadd_vv_i32m4(mul, mul_s, 8);
-  vint16m2_t sat = __riscv_vnclip_wx_i16m2(mul_add, 0, __RISCV_VXRM_RDN, 8);
+  vint16m2_t sat = sse2rvv_vnclip_wx_i16m2(mul_add, 0, __RISCV_VXRM_RDN, 8);
   return vreinterpretq_i16_m128i(
       __riscv_vnsra_wx_i16m1(__riscv_vreinterpret_v_i16m2_i32m2(sat), 0, 8));
 }
@@ -2326,30 +2382,34 @@ FORCE_INLINE __m128 _mm_movelh_ps(__m128 a, __m128 b) {
 
 FORCE_INLINE int _mm_movemask_epi8(__m128i a) {
   vint8m1_t _a = vreinterpretq_m128i_i8(a);
-  vuint16m1_t nonzeros =
-      __riscv_vreinterpret_v_b8_u16m1(__riscv_vmslt_vx_i8m1_b8(_a, 0, 16));
-  return (int)__riscv_vmv_x_s_u16m1_u16(nonzeros);
+  vbool8_t _mask = __riscv_vmslt_vx_i8m1_b8(_a, 0, 16);
+  uint16_t _result;
+  sse2rvv_vsm_v_b8(_mask, (uint8_t *)&_result, 16);
+  return (int)_result;
 }
 
 FORCE_INLINE int _mm_movemask_pd(__m128d a) {
   vint64m1_t _a = vreinterpretq_m128d_i64(a);
-  vuint8m1_t nonzeros =
-      __riscv_vreinterpret_v_b64_u8m1(__riscv_vmslt_vx_i64m1_b64(_a, 0, 2));
-  return (int)(__riscv_vmv_x_s_u8m1_u8(nonzeros) & 0x3);
+  vbool64_t _mask = __riscv_vmslt_vx_i64m1_b64(_a, 0, 2);
+  uint8_t _result;
+  sse2rvv_vsm_v_b64(_mask, &_result, 2);
+  return (int)(_result & 0x3);
 }
 
 FORCE_INLINE int _mm_movemask_pi8(__m64 a) {
   vint8m1_t _a = vreinterpretq_m128i_i8(a);
-  vuint8m1_t nonzeros =
-      __riscv_vreinterpret_v_b8_u8m1(__riscv_vmslt_vx_i8m1_b8(_a, 0, 8));
-  return (int)__riscv_vmv_x_s_u8m1_u8(nonzeros);
+  vbool8_t _mask = __riscv_vmslt_vx_i8m1_b8(_a, 0, 8);
+  uint8_t _result;
+  sse2rvv_vsm_v_b8(_mask, &_result, 8);
+  return (int)_result;
 }
 
 FORCE_INLINE int _mm_movemask_ps(__m128 a) {
   vint32m1_t _a = vreinterpretq_m128_i32(a);
-  vuint8m1_t nonzeros =
-      __riscv_vreinterpret_v_b32_u8m1(__riscv_vmslt_vx_i32m1_b32(_a, 0, 4));
-  return (int)(__riscv_vmv_x_s_u8m1_u8(nonzeros) & 0xf);
+  vbool32_t _mask = __riscv_vmslt_vx_i32m1_b32(_a, 0, 4);
+  uint8_t _result;
+  sse2rvv_vsm_v_b32(_mask, &_result, 4);
+  return (int)(_result & 0xf);
 }
 
 FORCE_INLINE __m64 _mm_movepi64_pi64(__m128i a) {
@@ -2439,7 +2499,7 @@ FORCE_INLINE __m128i _mm_mulhrs_epi16(__m128i a, __m128i b) {
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(_a, _b, 8);
   vint32m2_t sra = __riscv_vsra_vx_i32m2(ab_mul, 14, 8);
   return vreinterpretq_i16_m128i(
-      __riscv_vnclip_wx_i16m1(sra, 1, __RISCV_VXRM_RNU, 8));
+      sse2rvv_vnclip_wx_i16m1(sra, 1, __RISCV_VXRM_RNU, 8));
 }
 
 FORCE_INLINE __m64 _mm_mulhrs_pi16(__m64 a, __m64 b) {
@@ -2448,7 +2508,7 @@ FORCE_INLINE __m64 _mm_mulhrs_pi16(__m64 a, __m64 b) {
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(_a, _b, 8);
   vint32m2_t sra = __riscv_vsra_vx_i32m2(ab_mul, 14, 8);
   return vreinterpretq_i16_m64(
-      __riscv_vnclip_wx_i16m1(sra, 1, __RISCV_VXRM_RNU, 8));
+      sse2rvv_vnclip_wx_i16m1(sra, 1, __RISCV_VXRM_RNU, 8));
 }
 
 FORCE_INLINE __m128i _mm_mullo_epi16(__m128i a, __m128i b) {
@@ -2485,9 +2545,9 @@ FORCE_INLINE __m128i _mm_packs_epi16(__m128i a, __m128i b) {
   vint16m1_t _a = vreinterpretq_m128i_i16(a);
   vint16m1_t _b = vreinterpretq_m128i_i16(b);
   vint8m1_t a_sat = __riscv_vlmul_ext_v_i8mf2_i8m1(
-      __riscv_vnclip_wx_i8mf2(_a, 0, __RISCV_VXRM_RDN, 8));
+      sse2rvv_vnclip_wx_i8mf2(_a, 0, __RISCV_VXRM_RDN, 8));
   vint8m1_t b_sat = __riscv_vlmul_ext_v_i8mf2_i8m1(
-      __riscv_vnclip_wx_i8mf2(_b, 0, __RISCV_VXRM_RDN, 8));
+      sse2rvv_vnclip_wx_i8mf2(_b, 0, __RISCV_VXRM_RDN, 8));
   return vreinterpretq_i8_m128i(
       __riscv_vslideup_vx_i8m1_tu(a_sat, b_sat, 8, 16));
 }
@@ -2496,9 +2556,9 @@ FORCE_INLINE __m128i _mm_packs_epi32(__m128i a, __m128i b) {
   vint32m1_t _a = vreinterpretq_m128i_i32(a);
   vint32m1_t _b = vreinterpretq_m128i_i32(b);
   vint16m1_t a_sat = __riscv_vlmul_ext_v_i16mf2_i16m1(
-      __riscv_vnclip_wx_i16mf2(_a, 0, __RISCV_VXRM_RDN, 4));
+      sse2rvv_vnclip_wx_i16mf2(_a, 0, __RISCV_VXRM_RDN, 4));
   vint16m1_t b_sat = __riscv_vlmul_ext_v_i16mf2_i16m1(
-      __riscv_vnclip_wx_i16mf2(_b, 0, __RISCV_VXRM_RDN, 4));
+      sse2rvv_vnclip_wx_i16mf2(_b, 0, __RISCV_VXRM_RDN, 4));
   return vreinterpretq_i16_m128i(
       __riscv_vslideup_vx_i16m1_tu(a_sat, b_sat, 4, 8));
 }
@@ -2587,24 +2647,47 @@ FORCE_INLINE __m128 _mm_rcp_ss(__m128 a) {
 // FORCE_INLINE __m128d _mm_round_pd (__m128d a, int rounding) {}
 
 FORCE_INLINE __m128 _mm_round_ps(__m128 a, int rounding) {
+  // Use scalar rounding functions (same as _mm_floor_ps/_mm_ceil_ps) to
+  // correctly handle negative zero and NaN/Inf pass-through.  The
+  // float→int→float approach loses the sign of zero (e.g. truncf(-0.25f)
+  // returns -0.0f but int(0)→float gives +0.0f), causing bitwise mismatches.
   vfloat32m1_t _a = vreinterpretq_m128_f32(a);
+  float arr[4];
+  __riscv_vse32_v_f32m1(arr, _a, 4);
   switch (rounding) {
-  case (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC):
-    return vreinterpretq_f32_m128(__riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RNE, 4), 4));
-  case (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC):
-    return vreinterpretq_f32_m128(__riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RDN, 4), 4));
-  case (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC):
-    return vreinterpretq_f32_m128(__riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RUP, 4), 4));
-  case (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC):
-    return vreinterpretq_f32_m128(__riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(_a, __RISCV_FRM_RTZ, 4), 4));
-  default: //_MM_FROUND_CUR_DIRECTION
-    return vreinterpretq_f32_m128(
-        __riscv_vfcvt_f_x_v_f32m1(__riscv_vfcvt_x_f_v_i32m1(_a, 4), 4));
+  case (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC): {
+    // Must use RNE regardless of the current FP rounding mode.
+    union {
+      fcsr_bitfield field;
+      uint32_t value;
+    } r;
+    __asm__ volatile("csrr %0, fcsr" : "=r"(r));
+    uint32_t saved = r.value;
+    r.field.frm = __RISCV_FRM_RNE;
+    __asm__ volatile("csrw fcsr, %0" : : "r"(r));
+    for (int i = 0; i < 4; i++)
+      arr[i] = nearbyintf(arr[i]);
+    __asm__ volatile("csrw fcsr, %0" : : "r"(saved));
+    break;
   }
+  case (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC):
+    for (int i = 0; i < 4; i++)
+      arr[i] = floorf(arr[i]);
+    break;
+  case (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC):
+    for (int i = 0; i < 4; i++)
+      arr[i] = ceilf(arr[i]);
+    break;
+  case (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC):
+    for (int i = 0; i < 4; i++)
+      arr[i] = truncf(arr[i]);
+    break;
+  default: // _MM_FROUND_CUR_DIRECTION
+    for (int i = 0; i < 4; i++)
+      arr[i] = nearbyintf(arr[i]);
+    break;
+  }
+  return vreinterpretq_f32_m128(__riscv_vle32_v_f32m1(arr, 4));
 }
 
 // FORCE_INLINE __m128d _mm_round_sd (__m128d a, __m128d b, int rounding) {}
@@ -3354,7 +3437,8 @@ FORCE_INLINE __m128d _mm_sub_sd(__m128d a, __m128d b) {
   vfloat64m1_t _a = vreinterpretq_m128d_f64(a);
   vfloat64m1_t _b = vreinterpretq_m128d_f64(b);
   vfloat64m1_t sub = __riscv_vfsub_vv_f64m1(_a, _b, 2);
-  vbool64_t mask = __riscv_vreinterpret_v_u8m1_b64(__riscv_vmv_v_x_u8m1(1, 8));
+  uint8_t _mask_val = 1;
+  vbool64_t mask = __riscv_vlm_v_b64(&_mask_val, 2);
   return vreinterpretq_f64_m128d(__riscv_vmerge_vvm_f64m1(_a, sub, mask, 2));
 }
 
@@ -3368,7 +3452,8 @@ FORCE_INLINE __m128 _mm_sub_ss(__m128 a, __m128 b) {
   vfloat32m1_t _a = vreinterpretq_m128_f32(a);
   vfloat32m1_t _b = vreinterpretq_m128_f32(b);
   vfloat32m1_t sub = __riscv_vfsub_vv_f32m1(_a, _b, 4);
-  vbool32_t mask = __riscv_vreinterpret_v_u8m1_b32(__riscv_vmv_v_x_u8m1(1, 8));
+  uint8_t _mask_val = 1;
+  vbool32_t mask = __riscv_vlm_v_b32(&_mask_val, 4);
   return vreinterpretq_f32_m128(__riscv_vmerge_vvm_f32m1(_a, sub, mask, 4));
 }
 

--- a/tests/compat_test.cpp
+++ b/tests/compat_test.cpp
@@ -1,0 +1,395 @@
+// compat_test.cpp
+//
+// Focused regression tests for the RVV intrinsics compatibility fixes
+// (old-spec compilers: Bianbu GCC 13/14).  Each test covers one of the three
+// API differences that were patched:
+//
+//  1. __riscv_vreinterpret_v_<int>_b* / _b*_<int>  → vlm / vsm
+//  2. __RISCV_VXRM_RNU / vaaddu / vnclip without rounding-mode param
+//  3. __RISCV_FRM_* / vfcvt_x_f_v_i32m1_rm without explicit frm param
+//
+// Build (cross): riscv64-linux-gnu-g++ -I. -march=rv64gcv_zba -static \
+//                  tests/compat_test.cpp -o tests/compat_test -lm
+
+#include "sse2rvv.h"
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                                       \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      printf("FAIL: %s\n", msg);                                              \
+      ++failures;                                                              \
+    } else {                                                                   \
+      printf("PASS: %s\n", msg);                                              \
+    }                                                                          \
+  } while (0)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static void get_f32(__m128 v, float out[4]) { memcpy(out, &v, 16); }
+static void get_f64(__m128d v, double out[2]) { memcpy(out, &v, 16); }
+static void get_i8(__m128i v, int8_t out[16]) { memcpy(out, &v, 16); }
+static void get_i16(__m128i v, int16_t out[8]) { memcpy(out, &v, 16); }
+static void get_i32(__m128i v, int32_t out[4]) { memcpy(out, &v, 16); }
+static void get_u16(__m128i v, uint16_t out[8]) { memcpy(out, &v, 16); }
+static void get_u8(__m128i v, uint8_t out[16]) { memcpy(out, &v, 16); }
+
+// ── Group 1: vlm / vsm mask load-store ──────────────────────────────────────
+
+// _mm_addsub_ps: even lanes subtract, odd lanes add
+static void test_addsub_ps(void) {
+  float a[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float b[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+  __m128 va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_addsub_ps(va, vb);
+  float r[4];
+  get_f32(vc, r);
+  // expected: [1-0.5, 2+0.5, 3-0.5, 4+0.5] = [0.5, 2.5, 2.5, 4.5]
+  CHECK(r[0] == 0.5f && r[1] == 2.5f && r[2] == 2.5f && r[3] == 4.5f,
+        "_mm_addsub_ps");
+}
+
+// _mm_blend_epi16: imm8=0b00001100 selects b for lanes 2,3
+static void test_blend_epi16(void) {
+  int16_t a[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  int16_t b[8] = {10, 20, 30, 40, 50, 60, 70, 80};
+  __m128i va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_blend_epi16(va, vb, 0x0C); // lanes 2,3 from b
+  int16_t r[8];
+  get_i16(vc, r);
+  CHECK(r[0] == 1 && r[1] == 2 && r[2] == 30 && r[3] == 40 && r[4] == 5 &&
+            r[5] == 6 && r[6] == 7 && r[7] == 8,
+        "_mm_blend_epi16(imm=0x0C)");
+}
+
+// _mm_blend_pd: imm8=0x1 → lane 0 from b
+static void test_blend_pd(void) {
+  double a[2] = {1.0, 2.0};
+  double b[2] = {10.0, 20.0};
+  __m128d va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_blend_pd(va, vb, 0x1);
+  double r[2];
+  get_f64(vc, r);
+  CHECK(r[0] == 10.0 && r[1] == 2.0, "_mm_blend_pd(imm=0x1)");
+}
+
+// _mm_blend_ps: imm8=0x5 (0101) → lanes 0,2 from b
+static void test_blend_ps(void) {
+  float a[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float b[4] = {10.0f, 20.0f, 30.0f, 40.0f};
+  __m128 va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_blend_ps(va, vb, 0x5);
+  float r[4];
+  get_f32(vc, r);
+  CHECK(r[0] == 10.0f && r[1] == 2.0f && r[2] == 30.0f && r[3] == 4.0f,
+        "_mm_blend_ps(imm=0x5)");
+}
+
+// _mm_hadd_pd: r[0]=a[0]+a[1], r[1]=b[0]+b[1]
+static void test_hadd_pd(void) {
+  double a[2] = {1.0, 2.0};
+  double b[2] = {3.0, 4.0};
+  __m128d va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_hadd_pd(va, vb);
+  double r[2];
+  get_f64(vc, r);
+  CHECK(r[0] == 3.0 && r[1] == 7.0, "_mm_hadd_pd");
+}
+
+// _mm_hsub_pd: r[0]=a[0]-a[1], r[1]=b[0]-b[1]
+static void test_hsub_pd(void) {
+  double a[2] = {5.0, 2.0};
+  double b[2] = {10.0, 3.0};
+  __m128d va, vb, vc;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  vc = _mm_hsub_pd(va, vb);
+  double r[2];
+  get_f64(vc, r);
+  CHECK(r[0] == 3.0 && r[1] == 7.0, "_mm_hsub_pd");
+}
+
+// _mm_movemask_epi8: sign bits of 16 bytes
+static void test_movemask_epi8(void) {
+  int8_t a[16] = {-1, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1};
+  __m128i va;
+  memcpy(&va, a, 16);
+  int mask = _mm_movemask_epi8(va);
+  // lanes 0,2,15 are negative → bits 0,2,15 set = 0x8005
+  CHECK(mask == 0x8005, "_mm_movemask_epi8");
+}
+
+// _mm_movemask_pd: sign bits of 2 doubles
+static void test_movemask_pd(void) {
+  double a[2] = {-1.0, 1.0};
+  __m128d va;
+  memcpy(&va, a, 16);
+  int mask = _mm_movemask_pd(va);
+  CHECK(mask == 0x1, "_mm_movemask_pd");
+}
+
+// _mm_movemask_ps: sign bits of 4 floats
+static void test_movemask_ps(void) {
+  float a[4] = {-1.0f, 1.0f, -1.0f, 1.0f};
+  __m128 va;
+  memcpy(&va, a, 16);
+  int mask = _mm_movemask_ps(va);
+  CHECK(mask == 0x5, "_mm_movemask_ps"); // bits 0,2 set
+}
+
+// _mm_movemask_pi8: sign bits of 8 bytes (__m64)
+static void test_movemask_pi8(void) {
+  int8_t a[8] = {-1, 0, 0, -1, 0, 0, 0, 0};
+  __m64 va;
+  memcpy(&va, a, 8);
+  int mask = _mm_movemask_pi8(va);
+  CHECK((mask & 0xff) == 0x09, "_mm_movemask_pi8"); // bits 0,3 set
+}
+
+// _mm_insert_epi32: insert value 99 at lane 2
+static void test_insert_epi32(void) {
+  int32_t a[4] = {1, 2, 3, 4};
+  __m128i va;
+  memcpy(&va, a, 16);
+  __m128i vc = _mm_insert_epi32(va, 99, 2);
+  int32_t r[4];
+  get_i32(vc, r);
+  CHECK(r[0] == 1 && r[1] == 2 && r[2] == 99 && r[3] == 4,
+        "_mm_insert_epi32");
+}
+
+// _mm_insert_epi8: insert value 77 at lane 5
+static void test_insert_epi8(void) {
+  int8_t a[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  __m128i va;
+  memcpy(&va, a, 16);
+  __m128i vc = _mm_insert_epi8(va, 77, 5);
+  int8_t r[16];
+  get_i8(vc, r);
+  CHECK(r[5] == 77 && r[4] == 5 && r[6] == 7, "_mm_insert_epi8");
+}
+
+// _mm_loadu_si16: load a single 16-bit value into lane 0
+static void test_loadu_si16(void) {
+  int16_t src = 0x1234;
+  __m128i v = _mm_loadu_si16(&src);
+  int16_t r[8];
+  get_i16(v, r);
+  CHECK(r[0] == 0x1234 && r[1] == 0 && r[2] == 0, "_mm_loadu_si16");
+}
+
+// _mm_loadu_si32: load a single 32-bit value into lane 0
+static void test_loadu_si32(void) {
+  int32_t src = 0xDEADBEEF;
+  __m128i v = _mm_loadu_si32(&src);
+  int32_t r[4];
+  get_i32(v, r);
+  CHECK(r[0] == (int32_t)0xDEADBEEF && r[1] == 0 && r[2] == 0 && r[3] == 0,
+        "_mm_loadu_si32");
+}
+
+// _mm_sub_ss: subtract scalar, keep upper lanes unchanged
+static void test_sub_ss(void) {
+  float a[4] = {10.0f, 2.0f, 3.0f, 4.0f};
+  float b[4] = {1.0f, 99.0f, 99.0f, 99.0f};
+  __m128 va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128 vc = _mm_sub_ss(va, vb);
+  float r[4];
+  get_f32(vc, r);
+  CHECK(r[0] == 9.0f && r[1] == 2.0f && r[2] == 3.0f && r[3] == 4.0f,
+        "_mm_sub_ss");
+}
+
+// _mm_sub_sd: subtract scalar double, keep upper lane unchanged
+static void test_sub_sd(void) {
+  double a[2] = {10.0, 20.0};
+  double b[2] = {3.0, 99.0};
+  __m128d va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128d vc = _mm_sub_sd(va, vb);
+  double r[2];
+  get_f64(vc, r);
+  CHECK(r[0] == 7.0 && r[1] == 20.0, "_mm_sub_sd");
+}
+
+// ── Group 2: vaaddu / vnclip rounding-mode compat ────────────────────────────
+
+// _mm_avg_epu16: (a+b+1)>>1 for 8 uint16 lanes
+static void test_avg_epu16(void) {
+  uint16_t a[8] = {0, 1, 100, 200, 1000, 0xFFFE, 0xFFFF, 300};
+  uint16_t b[8] = {0, 1, 101, 201, 1001, 0xFFFF, 0xFFFF, 301};
+  __m128i va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128i vc = _mm_avg_epu16(va, vb);
+  uint16_t r[8];
+  get_u16(vc, r);
+  uint16_t expected[8];
+  for (int i = 0; i < 8; i++)
+    expected[i] = (uint16_t)(((uint32_t)a[i] + b[i] + 1) >> 1);
+  int ok = 1;
+  for (int i = 0; i < 8; i++)
+    ok &= (r[i] == expected[i]);
+  CHECK(ok, "_mm_avg_epu16");
+}
+
+// _mm_avg_epu8: (a+b+1)>>1 for 16 uint8 lanes
+static void test_avg_epu8(void) {
+  uint8_t a[16] = {0, 1, 100, 200, 255, 254, 3, 7, 10, 20, 30, 40, 50, 60, 70,
+                   80};
+  uint8_t b[16] = {0, 2, 101, 201, 255, 255, 4, 8, 11, 21, 31, 41, 51, 61, 71,
+                   81};
+  __m128i va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128i vc = _mm_avg_epu8(va, vb);
+  uint8_t r[16];
+  get_u8(vc, r);
+  int ok = 1;
+  for (int i = 0; i < 16; i++)
+    ok &= (r[i] == (uint8_t)(((uint32_t)a[i] + b[i] + 1) >> 1));
+  CHECK(ok, "_mm_avg_epu8");
+}
+
+// _mm_packs_epi16: saturate int16→int8
+static void test_packs_epi16(void) {
+  int16_t a[8] = {-200, -128, -1, 0, 127, 128, 200, 1000};
+  int16_t b[8] = {-1000, -129, 0, 1, 126, 127, 200, 300};
+  __m128i va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128i vc = _mm_packs_epi16(va, vb);
+  int8_t r[16];
+  get_i8(vc, r);
+  // a: -128,-128,-1,0,127,127,127,127
+  // b: -128,-128, 0,1,126,127,127,127
+  CHECK(r[0] == -128 && r[1] == -128 && r[2] == -1 && r[3] == 0 &&
+            r[4] == 127 && r[5] == 127 && r[6] == 127 && r[7] == 127 &&
+            r[8] == -128 && r[9] == -128 && r[10] == 0 && r[11] == 1 &&
+            r[12] == 126 && r[13] == 127 && r[14] == 127 && r[15] == 127,
+        "_mm_packs_epi16");
+}
+
+// _mm_packs_epi32: saturate int32→int16
+static void test_packs_epi32(void) {
+  int32_t a[4] = {-100000, -32768, 32767, 100000};
+  int32_t b[4] = {0, 1, -1, 32768};
+  __m128i va, vb;
+  memcpy(&va, a, 16);
+  memcpy(&vb, b, 16);
+  __m128i vc = _mm_packs_epi32(va, vb);
+  int16_t r[8];
+  get_i16(vc, r);
+  CHECK(r[0] == -32768 && r[1] == -32768 && r[2] == 32767 && r[3] == 32767 &&
+            r[4] == 0 && r[5] == 1 && r[6] == -1 && r[7] == 32767,
+        "_mm_packs_epi32");
+}
+
+// ── Group 3: vfcvt_x_f_v_i32m1_rm explicit rounding mode ────────────────────
+
+// _mm_cvt_ss2si: float to int (nearest-even by default)
+static void test_cvt_ss2si(void) {
+  float a[4] = {2.5f, 0.0f, 0.0f, 0.0f};
+  __m128 va;
+  memcpy(&va, a, 16);
+  int r = _mm_cvt_ss2si(va);
+  // 2.5 rounds to 2 (round-to-nearest-even)
+  CHECK(r == 2, "_mm_cvt_ss2si(2.5f) rounds to 2");
+
+  float b[4] = {-3.5f, 0.0f, 0.0f, 0.0f};
+  memcpy(&va, b, 16);
+  r = _mm_cvt_ss2si(va);
+  // -3.5 rounds to -4 (round-to-nearest-even)
+  CHECK(r == -4, "_mm_cvt_ss2si(-3.5f) rounds to -4");
+}
+
+// _mm_round_ps: explicit rounding modes
+static void test_round_ps(void) {
+  float a[4] = {1.6f, -1.6f, 2.4f, -2.4f};
+  __m128 va;
+  memcpy(&va, a, 16);
+
+  // round to nearest
+  __m128 r0 = _mm_round_ps(va, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+  float f0[4];
+  get_f32(r0, f0);
+  CHECK(f0[0] == 2.0f && f0[1] == -2.0f && f0[2] == 2.0f && f0[3] == -2.0f,
+        "_mm_round_ps nearest");
+
+  // round toward zero (truncate)
+  __m128 r1 = _mm_round_ps(va, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  float f1[4];
+  get_f32(r1, f1);
+  CHECK(f1[0] == 1.0f && f1[1] == -1.0f && f1[2] == 2.0f && f1[3] == -2.0f,
+        "_mm_round_ps truncate");
+
+  // round toward negative infinity (floor)
+  __m128 r2 = _mm_round_ps(va, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC);
+  float f2[4];
+  get_f32(r2, f2);
+  CHECK(f2[0] == 1.0f && f2[1] == -2.0f && f2[2] == 2.0f && f2[3] == -3.0f,
+        "_mm_round_ps floor");
+
+  // round toward positive infinity (ceil)
+  __m128 r3 = _mm_round_ps(va, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC);
+  float f3[4];
+  get_f32(r3, f3);
+  CHECK(f3[0] == 2.0f && f3[1] == -1.0f && f3[2] == 3.0f && f3[3] == -2.0f,
+        "_mm_round_ps ceil");
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+int main(void) {
+  printf("=== sse2rvv compat regression tests ===\n\n");
+
+  printf("-- vlm/vsm mask load/store --\n");
+  test_addsub_ps();
+  test_blend_epi16();
+  test_blend_pd();
+  test_blend_ps();
+  test_hadd_pd();
+  test_hsub_pd();
+  test_movemask_epi8();
+  test_movemask_pd();
+  test_movemask_ps();
+  test_movemask_pi8();
+  test_insert_epi32();
+  test_insert_epi8();
+  test_loadu_si16();
+  test_loadu_si32();
+  test_sub_ss();
+  test_sub_sd();
+
+  printf("\n-- vaaddu/vnclip rounding-mode compat --\n");
+  test_avg_epu16();
+  test_avg_epu8();
+  test_packs_epi16();
+  test_packs_epi32();
+
+  printf("\n-- vfcvt explicit rounding-mode compat --\n");
+  test_cvt_ss2si();
+  test_round_ps();
+
+  printf("\n=== %s (%d failure(s)) ===\n",
+         failures == 0 ? "ALL PASSED" : "SOME FAILED", failures);
+  return failures ? 1 : 0;
+}


### PR DESCRIPTION
Three categories of intrinsics from the pre-v0.12 RVV spec are absent on the Bianbu GCC 13/14 toolchain, causing build failures:

1. vreinterpret_v_<int>_b* / vreinterpret_v_b*_<int> Replaced with __riscv_vlm_v_b* (load mask from memory) and __riscv_vsm_v_b* (store mask to memory), which are available in all spec versions.  Affected: _mm_addsub_ps, _mm_blend_{epi16,pd,ps}, _mm_hadd_pd, _mm_hsub_pd, _mm_insert_{epi8,epi16,epi32,epi64,pi16,ps}, _mm_loadu_{si16,si32}, _mm_movemask_{epi8,pd,pi8,ps}, _mm_sub_{sd,ss}.

2. __RISCV_VXRM_* constants and vaaddu/vnclip without rounding-mode param Added #ifndef guards to define the constants, and sse2rvv_vaaddu_*/ sse2rvv_vnclip_* wrapper macros that drop the rounding-mode argument when SSE2RVV_MISSING_VXRM is detected.  Affected: _mm_avg_{epu8,epu16, pu8,pu16}, _mm_mulhrs_{epi16,pi16}, _mm_maddubs_{epi16,pi16}, _mm_packs_{epi16,epi32}.

3. __RISCV_FRM_* constants and vfcvt_x_f_v_i32m1_rm Same pattern: #ifndef guards for the constants and a sse2rvv_vfcvt_x_f_v_i32m1_rm wrapper that falls back to the no-frm variant on old toolchains.  Affected: _mm_cvt_ss2si, _mm_round_ps.

Also add tests/compat_test.cpp: 22 focused tests (with hardcoded expected values) covering all three compat areas, plus a `compat-test` Makefile target to build and run them.